### PR TITLE
add some more instructions, including for S3_ALIAS_HOST

### DIFF
--- a/s3.md
+++ b/s3.md
@@ -11,6 +11,10 @@ and how you configure them:
     S3_PROTOCOL
     S3_HOSTNAME
 
+And optionally:
+
+    S3_ALIAS_HOST
+
 # What / Why
 
 The most disk-space-intensive part of hosting a mastodon instance is hosting all
@@ -76,6 +80,15 @@ but NOT domain names like:
 
     https://masto.mycoolsite.s3.amazonaws.com
 
+The only other bucket settings that need to be changed are the four public access
+settings – "block new public ACLs," "remove public access granted through public ACLs,"
+"block new public bucket policies," and "block public and cross-account access if
+bucket has public policies." You should disable all four of these.
+
+In the end, the bucket will have the access status "Objects can be public," which
+means that objects aren't enumerable (using List Objects), but objects are still
+public if you know the URL. This is what we want for Mastodon media.
+
 The other bucket settings don't need to be changed, so you can now click
 "Create" to create the bucket.
 
@@ -88,7 +101,8 @@ Compliance**). On the side column, click on **Users**, then **Add user**. Put in
 a descriptive name (like "Mastodon-API"), and enable "Programmatic access". You
 can add this user to the "Administrators" group if you like, or if you're
 paranoid you can create a new group for it (make sure it has
-AmazonS3FullAccess). Finish creating the user, and copy its **Access key ID**
+AmazonS3FullAccess, or a [custom S3 access restricting it to a single bucket](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_deny-except-bucket.html)).
+Finish creating the user, and copy its **Access key ID**
 and **Secret access key** (which we'll call $AWS_ACCESS_KEY and $AWS_SECRET_ACCESS_KEY) 
 down somewhere -- you'll need them later.
 
@@ -111,15 +125,23 @@ Install the command line tool `s3cmd`:
 
     s3cmd --configure
 
-Navigate to your mastodon deployment folder, e.g.:
+(Note that this command will fail if the account only has access to a single bucket, but you can
+temporarily grant AmazonS3FullAccess just to run this command.)
 
-    cd ~mastodon/live
+You can test that it's working by doing:
+
+    echo "test" > tmp.txt
+    s3cmd --acl-public put tmp.txt s3://$S3_BUCKET/tmp.txt
+
+(Substitute the name of your bucket for $S3_BUCKET.)
+Now, navigate to your mastodon deployment folder, e.g.:
+
+    cd ~/mastodon/live
     
 Before copying over the content, you'll want to pare it down to the minimal amount possible to save
-on bandwidth. Run these two commands which remove old and silenced media:
+on bandwidth. Run this command to remove old remote media:
 
-    bundle exec rails mastodon:media:remove_silenced
-    bundle exec rails mastodon:media:remove_remote
+    RAILS_ENV=production ./bin/tootctl media remove --days=7
 
 Now run the following command. Substitute the name of your bucket for $S3_BUCKET:
 
@@ -134,6 +156,9 @@ be created between when this tool runs and when you switch out the config!
 If you're a fan of fancy shell commands, the following series of pipes will do several transfers in parallel:
 
     find -type f | cut -d"/" -f 2- | xargs -P 6 -I {} s3cmd --acl-public sync {} s3://$S3_BUCKET/$(echo {} | sed "s:public/system/\(.*\):\1:")
+
+Note that you should run the above command inside of the `live/public/system` directory,
+and you can use `-P 6` to use more or less than 6 parallel tasks.
 
 ### Filling out the config
 
@@ -166,6 +191,12 @@ for the content it displays on the page. I haven't yet determined why it needs
 to know the region but I assume it has something to do with the API calls it
 makes.
 
+Optionally, if you want to use your own URL for assets (e.g. `assets.myinstance.com`, you can set up
+[CloudFront and a custom CNAME](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html)).
+If you do, you'll want to tell Mastodon to use this custom URL when serving assets:
+
+    S3_ALIAS_HOST=assets.myinstance.com
+
 ## Restarting Mastodon
 
 Now restart your mastodon server (or start it up if it's a fresh one). e.g.:
@@ -181,6 +212,23 @@ people's avatars and attachments, and your attachment URLs look like the
 following, then you're good to go!
 
     https://cybre.s3-us-west-2.amazonaws.com/media_attachments/files/000/005/330/original/halebopp_dimai_960.jpg?1491719606
+
+## Follow-up
+
+Since there may still be URLs out there in the wild pointing to the old assets URLs, you'll
+also want to set up a redirect for them. In your nginx config, make `/packs` point
+to local resources (e.g. Webpack assets), whereas `/system` points to the new S3 bucket:
+
+```
+  location /packs {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    try_files $uri @proxy;
+  }
+
+  location /system {
+    rewrite ^/system(.*) https://assets.myinstance.com$1 permanent;
+  }
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
This S3 guide was incredibly helpful for setting up S3 on my own instances. I've added some small updates and clarifications to cover things like:

- public access settings, which I believe Amazon added after this document was written
- how to set up Cloudfront and S3_ALIAS_HOST
- how to set up a redirect from old asset URLs to new ones

Hope this is helpful for folks!