### PR TITLE
Tweak S3 command and nginx config

### DIFF
--- a/s3.md
+++ b/s3.md
@@ -145,7 +145,7 @@ on bandwidth. Run this command to remove old remote media:
 
 Now run the following command. Substitute the name of your bucket for $S3_BUCKET:
 
-    s3cmd --acl-public sync public/system/ s3://$S3_BUCKET
+    s3cmd --acl-public sync --add-header="Cache-Control:public, max-age=315576000, immutable" public/system/ s3://$S3_BUCKET
 
 This may take a while depending on how long your instance has been running.
 
@@ -155,7 +155,7 @@ be created between when this tool runs and when you switch out the config!
 
 If you're a fan of fancy shell commands, the following series of pipes will do several transfers in parallel:
 
-    find -type f | cut -d"/" -f 2- | xargs -P 6 -I {} s3cmd --acl-public sync {} s3://$S3_BUCKET/$(echo {} | sed "s:public/system/\(.*\):\1:")
+    find -type f | cut -d"/" -f 2- | xargs -P 6 -I {} s3cmd --acl-public sync --add-header="Cache-Control:public, max-age=315576000, immutable" {} s3://$S3_BUCKET/$(echo {} | sed "s:public/system/\(.*\):\1:")
 
 Note that you should run the above command inside of the `live/public/system` directory,
 and you can use `-P 6` to use more or less than 6 parallel tasks.
@@ -220,7 +220,7 @@ also want to set up a redirect for them. In your nginx config, make `/packs` poi
 to local resources (e.g. Webpack assets), whereas `/system` points to the new S3 bucket:
 
 ```
-  location /packs {
+  location ~ ^/(emoji|packs) {
     add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri @proxy;
   }


### PR DESCRIPTION
Thanks for merging my last PR! I found a couple more things that folks should do when migrating to S3. This adds the proper caching header, as defined in the latest version of Mastodon: https://github.com/tootsuite/mastodon/pull/9722 . It also ensures that non-custom emoji are properly served with immutable caching via nginx.

It's no fun going back and recursively adding the right cache headers to every object in S3; hopefully this will save some folks that extra step. :sweat_smile: